### PR TITLE
Some sort of feedback

### DIFF
--- a/PollingConsumer.Tests/paket.references
+++ b/PollingConsumer.Tests/paket.references
@@ -1,2 +1,3 @@
-FsCheck.Xunit
+Hedgehog
+xunit.core
 Unquote

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,7 +1,8 @@
 source https://www.nuget.org/api/v2/
 
 nuget FAKE
-nuget FsCheck.Xunit
+nuget Hedgehog
 nuget FSharp.Core
 nuget Unquote
+nuget xunit.core
 nuget xunit.runner.console


### PR DESCRIPTION
I was looking at the current implementation of [`PollingConsumerProperties`](https://github.com/ploeh/PollingConsumer/blob/fc2b320a6b672d7ee3452fbb28ad6ab057d052e4/PollingConsumer.Tests/PollingConsumerProperties.fs), and I thought I could do a port, primarily for my own interest, to [Hedgehog](https://github.com/hedgehogqa/fsharp-hedgehog), in order to remove the noise from `<!>`, `<*>`, `Arb.fromGen` and `Prop.forAll`, and fiddle with the automatic/integrated shrinking.

Of course, this isn't perfect either; from 136 lines of code, it went to 155, and I'm positive that it *might* be introducing False Positives and/or False Negatives.

But I thought I'd share it with you anyway, in the form of a pull request, just in case you find it useful, and to provide some sort of feedback.

*(Closing the pull request right away since the goal isn't to get this merged into `master`.)*

---

Since all NuGet Packages are checked in, I didn't want to run [paket install](https://fsprojects.github.io/Paket/paket-install.html), as this would produce a large diff. It should be done fairly easily though with something like:

```bash
# Assuming that `git clean -xdf` has run first.
$ .paket/paket.bootstrapper.exe
$ .paket/paket.exe install
$ ./build.sh
```